### PR TITLE
Handle merging of blocks.json Atlas from 1.19.3

### DIFF
--- a/merge_folder.php
+++ b/merge_folder.php
@@ -153,6 +153,20 @@ function mergeFolder($fromFolder, $toFolder) {
         if (!$fromJSON) {
             continue;
         }
+        
+        if (endsWith($fromFile, 'assets/minecraft/atlases/blocks.json')) {
+            foreach ($fromJSON as $key => $value) {
+                if ($key == "sources" ) {
+                    foreach($value as $atlas => $atlasDefinition) {
+                        if(!in_array($atlasDefinition, $toJSON["sources"])){
+                            array_push($toJSON["sources"],$atlasDefinition);
+                        }
+                    }
+                }
+            }
+            file_put_contents($toFile, json_encode($toJSON, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+            continue;
+        }
 
         if (endsWith($fromFile, 'assets/minecraft/sounds.json')) {
             foreach ($fromJSON as $key => $sound) {


### PR DESCRIPTION
The only packs I have noticed that have conflicting atlas files (QualityArmory and Magic) don't have any conflicts other than in blocks.json, so I'm not certain that this same fix would apply to other atlas files.     
I don't pretend to understand the rest of the php well enough (or indeed the other atlas files) to try to make the fix any more generic than I can currently test myself, but hopefully this will cover a decent chunk of resourcepack incompatibilities.

I've documented more info as to why this sort of thing is required (with pictures) over on [the Discord](https://discord.com/channels/580099743875727363/788118000494051398/1082970112740573225)     
But in a nutshell, the merger is not actually merging these new json files as you'd expect it to. Probably due to the particular formatting of the objects within and which parts are considered boilerplate and which are actual 'content', differing to the 'usual'.